### PR TITLE
changed from oldwinapi to winim, added a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.exe
+*.code-workspace

--- a/examples/service1.nim
+++ b/examples/service1.nim
@@ -1,6 +1,6 @@
 # A simple demo service
-import ../winservice, ../winServiceControl
-import oldwinapi/windows
+import ../winservice
+import winim/lean
 import times, os
 
 const SERVICE_NAME = "ZZZ_TEST_SERVICE_2"

--- a/winServiceControl.nim
+++ b/winServiceControl.nim
@@ -9,8 +9,7 @@
 ## register, delete and control windows services.
 # loosely based on: https://docs.microsoft.com/de-de/windows/desktop/Services/svc-cpp
 
-import oldwinapi/windows
-import os
+import winim/lean
 
 proc close*(service: SC_HANDLE): bool = return service.CloseServiceHandle().bool
 
@@ -103,6 +102,7 @@ proc stopService(scmManager: SC_HANDLE, serviceName: string): bool =
     echo "Stop service not implemented yet"
 
 when isMainModule:
+    import os
     ## Register the service
     var scm = openServiceManager()
     # echo scm.deleteService("ZZZ_SERVICE_NAME4")

--- a/winservice.nim
+++ b/winservice.nim
@@ -13,8 +13,7 @@
 # https://docs.microsoft.com/en-us/windows/desktop/api/winsvc/nf-winsvc-controlservice
 
 
-import winServiceControl
-import oldwinapi/windows
+import winim/lean
 
 type ServiceMain = proc(gSvcStatus: SERVICE_STATUS)
 
@@ -41,7 +40,7 @@ proc reportSvcStatus*(dwCurrentState, dwWin32ExitCode, dwWaitHint: DWORD) =
     # Report the status of the service to the SCM.
     echo "SetServiceStatus: " & $SetServiceStatus(gSvcStatusHandle, addr gSvcStatus)
 
-proc svcCtrlHandler(dwCtrl: DWORD): WINBOOL {.stdcall.} =
+proc svcCtrlHandler(dwCtrl: DWORD) {.stdcall.} =
     ## Handle the requested control code. 
     case dwCtrl
     of SERVICE_CONTROL_STOP:
@@ -55,7 +54,7 @@ proc svcCtrlHandler(dwCtrl: DWORD): WINBOOL {.stdcall.} =
 
 template wrapServiceMain*(mainProc: ServiceMain): LPSERVICE_MAIN_FUNCTION = 
     ## wraps a nim proc in a LPSERVICE_MAIN_FUNCTION
-    proc serviceMainFunction(dwArgc: DWORD, lpszArgv: LPTSTR) {.stdcall.} =
+    proc serviceMainFunction(dwArgc: DWORD, lpszArgv: ptr LPTSTR) {.stdcall.} =
         gSvcStatusHandle = RegisterServiceCtrlHandler(
             SERVICE_NAME,
             svcCtrlHandler


### PR DESCRIPTION
Using nim 1.4.8, oldwinapi does not compile (on my machine at least)
Tried using std/winlean, but this is missing a bunch of definitions.

So this PR uses winim instead. It compiles and works fine.

It might be worthwhile to add a nimble file to pull that dependency

Signed-off-by: cark <carkhy@gmail.com>